### PR TITLE
Update broken "external plugins" link

### DIFF
--- a/content/telegraf/v1.19/external_plugins/write_external_plugin.md
+++ b/content/telegraf/v1.19/external_plugins/write_external_plugin.md
@@ -10,7 +10,7 @@ menu:
 Set up your plugin to use it with `execd`.
 
 {{% note %}}
-For listed [external plugins](/EXTERNAL_PLUGINS.md), the author of the external plugin is also responsible for the maintenance
+For listed [external plugins](https://github.com/influxdata/telegraf/blob/master/EXTERNAL_PLUGINS.md), the author of the external plugin is also responsible for the maintenance
 and feature development of external plugins.
 {{% /note %}}
 


### PR DESCRIPTION
Link target is referenced based off github project URL, while the page is displayed on influxdata site.

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
