### PR TITLE
Update broken "processors.execd" link

### DIFF
--- a/content/telegraf/v1.19/external_plugins/write_external_plugin.md
+++ b/content/telegraf/v1.19/external_plugins/write_external_plugin.md
@@ -26,5 +26,5 @@ Include the following steps:
      - Commands to build your binary
      - Location to edit your `telegraf.conf`
      - Configuration to run your external plugin with [inputs.execd](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/execd),
-     [processors.execd](/plugins/processors/execd) or [outputs.execd](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/execd)
+     [processors.execd](https://github.com/influxdata/telegraf/blob/master/plugins/processors/execd) or [outputs.execd](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/execd)
 4. Submit your plugin by opening a PR to add your external plugin to the [/EXTERNAL_PLUGINS.md](https://github.com/influxdata/telegraf/blob/master/EXTERNAL_PLUGINS.md) list. Include the plugin name, a link to the plugin repository and a short description of the plugin.


### PR DESCRIPTION
Link target is referenced based off github project URL, while the page is displayed on influxdata site.

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
