### PR TITLE
Update broken links in external_plugins/_index.md

### DIFF
--- a/content/telegraf/v1.19/external_plugins/_index.md
+++ b/content/telegraf/v1.19/external_plugins/_index.md
@@ -7,14 +7,14 @@ menu:
      weight: 50
 ---
 
-[External plugins](/EXTERNAL_PLUGINS.md) are external programs that are built outside
+[External plugins](https://github.com/influxdata/telegraf/tree/master/EXTERNAL_PLUGINS.md) are external programs that are built outside
 of Telegraf that can run through an `execd` plugin. These external plugins allow for
 more flexibility compared to internal Telegraf plugins. Benefits to using external plugins include:
 - Access to libraries not written in Go
 - Using licensed software (not available to open source community)
 - Including large dependencies that would otherwise bloat Telegraf
 - Using your external plugin immediately without waiting for the Telegraf team to publish
-- Easily convert plugins between internal and external using the [shim](/plugins/common/shim)
+- Easily convert plugins between internal and external using the [shim](https://github.com/influxdata/telegraf/tree/master/plugins/common/shim)
 
 
 


### PR DESCRIPTION
Link targets are referenced based off github project URL, while the page is displayed on influxdata site.

Closes #

_Describe your proposed changes here._

- [ ] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/docs-v2/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
